### PR TITLE
Add query string feature for PUT /rules/{file} endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.4 / 2024-01-28
+
+* [ENHANCEMENT] Added HTTP query string: `recreate=true|false` for `PUT /api/v1/rules/{file}` endpoint.
+* [CHANGE] Log format includes HTTP query strings passed by user.
+
 ## 0.1.3 / 2024-01-21
 
 * [CHANGE] Upgraded FastAPI module from `0.95.1` to `0.109.0`.

--- a/src/api/v1/endpoints/reverse_proxy.py
+++ b/src/api/v1/endpoints/reverse_proxy.py
@@ -25,7 +25,7 @@ async def _reverse_proxy(request: Request):
         extra={
             "status": rp_resp.status_code,
             "method": request.method,
-            "path": rp_resp.url.path})
+            "request_path": rp_resp.url.path})
     return StreamingResponse(
         rp_resp.aiter_raw(),
         status_code=rp_resp.status_code,

--- a/src/api/v1/endpoints/rules.py
+++ b/src/api/v1/endpoints/rules.py
@@ -45,7 +45,7 @@ def create_prometheus_rule(
         extra={
             "status": response.status_code,
             "method": request.method,
-            "path": request.url.path})
+            "request_path": f"{request.url.path}{'?' + request.url.query if request.url.query else ''}"})
 
     resp = {"status": sts, "message": msg}
     if request.method == "POST":
@@ -215,7 +215,7 @@ async def update(
             extra={
                 "status": response.status_code,
                 "method": request.method,
-                "path": request.url.path})
+                "request_path": f"{request.url.path}{'?' + request.url.query if request.url.query else ''}"})
         return {"status": "error", "message": msg}
     return create_prometheus_rule(r, request, response, file)
 
@@ -281,7 +281,7 @@ async def delete(file, request: Request, response: Response):
         extra={
             "status": response.status_code,
             "method": request.method,
-            "path": request.url.path})
+            "request_path": f"{request.url.path}{'?' + request.url.query if request.url.query else ''}"})
     return {
         "status": sts,
         "message": msg} if response.status_code != 204 else response.status_code


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- Adding HTTP query string: `recreate=true|false` for `PUT /api/v1/rules/{file}` endpoint. With this feature, files can be entirely recreated/overrided via PUT request.
- Now log format includes HTTP query strings passed by the user.

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
