### PR TITLE
Add support for exposing Prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.5 / 2024-02-25
+
+* [ENHANCEMENT] Added support for exposing Prometheus metrics. The corresponding metrics are available under the path 
+`/api-metrics`. The `/metrics` endpoint is also accessible for exposing the metrics of the Prometheus server.
+* [BUGFIX] Fixed startup check of filesystem permissions in case of OSError.  
+
 ## 0.1.4 / 2024-01-28
 
 * [ENHANCEMENT] Added HTTP query string: `recreate=true|false` for `PUT /api/v1/rules/{file}` endpoint.

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ required parameters:
 <!-- ROADMAP -->
 ## Roadmap
 
-- [ ] Add Prometheus instrumentation to expose metrics.
+- [x] Add Prometheus instrumentation to expose metrics.
 - [ ] Add a Bulk API to allow the creation of multiple rules via a single API call.
-- [ ] Implement a way to update existing rules through the API.
+- [x] Implement a way to update existing rules through the API.
 
 <!-- CONTACT -->
 ## Author and Maintainer

--- a/main.py
+++ b/main.py
@@ -13,11 +13,11 @@ args = arg_parser()
 prom_addr, rule_path = args.get("prom.addr"), args.get("rule.path")
 host, port = args.get("web.listen_address").split(":")
 
-if False in [settings.check_prom_http_connection(prom_addr),
+if not all([settings.check_prom_http_connection(prom_addr),
              settings.check_reload_api_status(prom_addr),
              settings.check_rules_directory(rule_path),
              settings.check_fs_permissions(rule_path),
-             rule_schema_status]:
+             rule_schema_status]):
     sys.exit()
 
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from src.utils.schemas import rule_schema_status
 from src.utils.arguments import arg_parser
 from src.api.v1.api import api_router
 from src.utils.openapi import openapi
+from src.utils.metrics import metrics
 from src.utils.log import logger
 from src.utils import settings
 from fastapi import FastAPI
@@ -26,6 +27,7 @@ def custom_openapi_wrapper():
 
 app = FastAPI(swagger_ui_parameters={"defaultModelsExpandDepth": -1})
 app.openapi = custom_openapi_wrapper
+metrics(app)
 app.include_router(api_router)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+prometheus-fastapi-instrumentator==6.1.0
 python-json-logger==2.0.7
 email-validator==2.0.0
 fastapi==0.109.0

--- a/src/api/v1/endpoints/rules.py
+++ b/src/api/v1/endpoints/rules.py
@@ -209,7 +209,7 @@ async def update(
             return resp
 
         response.status_code = status.HTTP_409_CONFLICT
-        msg = f"The requested file already exists."
+        msg = "The requested file already exists."
         logger.info(
             msg=msg,
             extra={

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,0 +1,23 @@
+from prometheus_fastapi_instrumentator import PrometheusFastApiInstrumentator
+from fastapi import FastAPI
+from .log import logger
+from sys import modules
+
+
+def metrics(app: FastAPI):
+    """
+    This function exposes Prometheus
+    metrics for prometheus-api service
+    """
+    metrics_path = "/api-metrics"
+    try:
+        instrumentator = PrometheusFastApiInstrumentator(
+            should_group_status_codes=False,
+            excluded_handlers=["/{path:path}", "/.*metrics"]
+        )
+        instrumentator.instrument(app)
+        instrumentator.expose(app, endpoint=metrics_path)
+    except BaseException as e:
+        logger.error(f"{modules[__name__], e}")
+    else:
+        logger.info(f"Successfully started metrics endpoint at {metrics_path} path")

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -16,7 +16,7 @@ def metrics(app: FastAPI):
             excluded_handlers=["/{path:path}", "/.*metrics"]
         )
         instrumentator.instrument(app)
-        instrumentator.expose(app, endpoint=metrics_path)
+        instrumentator.expose(app, endpoint=metrics_path, tags=["metrics"])
     except BaseException as e:
         logger.error(f"{modules[__name__], e}")
     else:

--- a/src/utils/openapi.py
+++ b/src/utils/openapi.py
@@ -16,7 +16,7 @@ def openapi(app: FastAPI):
                     "providing additional features and addressing its limitations. "
                     "Running as a sidecar alongside the Prometheus server enables "
                     "users to extend the capabilities of the API.",
-        version="0.1.4",
+        version="0.1.5",
         contact={
             "name": "Hayk Davtyan",
             "url": "https://hayk96.github.io",

--- a/src/utils/settings.py
+++ b/src/utils/settings.py
@@ -57,7 +57,7 @@ def check_fs_permissions(prometheus_rules_dir) -> bool:
     except OSError as e:
         logger.error(
             f"The temporary file could not be created or deleted for testing permissions. {e}")
-        return True
+        return False
     else:
         logger.debug(
             "The application has the necessary permissions to access the rule files directory.")


### PR DESCRIPTION
**1. What this PR does / why we need it:**

* [ENHANCEMENT] Added support for exposing Prometheus metrics. The corresponding metrics are available under the path `/api-metrics`. The `/metrics` endpoint is also accessible for exposing the metrics of the Prometheus server.
* [BUGFIX] Fixed startup check of filesystem permissions in case of OSError.

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
