### PR TITLE
Serve remote JS script through Cloudflare CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1 / 2024-05-07
+
+* [CHANGE] Serve remote JS script through Cloudflare CDN. No API changes.  #17
+
 ## 0.2.0 / 2024-05-02
 
 * [ENHANCEMENT] Added support of Web UI for better management of the Prometheus rules through UI. #14 

--- a/src/utils/openapi.py
+++ b/src/utils/openapi.py
@@ -16,7 +16,7 @@ def openapi(app: FastAPI):
                     "providing additional features and addressing its limitations. "
                     "Running as a sidecar alongside the Prometheus server enables "
                     "users to extend the capabilities of the API.",
-        version="0.2.0",
+        version="0.2.1",
         contact={
             "name": "Hayk Davtyan",
             "url": "https://hayk96.github.io",

--- a/ui/rules-management/index.html
+++ b/ui/rules-management/index.html
@@ -58,7 +58,7 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4/dist/js-yaml.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.2/codemirror.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.2/mode/yaml/yaml.min.js"></script>
     <script type="" src="/rules-management/script.js"></script>


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- This PR replaces the remote JS script URL by pointing to the Cloudflare's CDNs.

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
