### PR TITLE
fix(api): Fix the issue of statically defined file in the /export API

### DIFF
--- a/src/api/v1/endpoints/export.py
+++ b/src/api/v1/endpoints/export.py
@@ -67,9 +67,9 @@ async def export(
         ]
 ):
     data = data.dict()
-    filename = "data.csv"
     expr, start = data.get("expr"), data.get("start")
     end, step = data.get("end"), data.get("step")
+    file = None
     validation_status, response.status_code, sts, msg = exp.validate_request(
         "export.json", data)
     if validation_status:
@@ -80,8 +80,8 @@ async def export(
             end=end, step=step)
         if resp_status:
             labels, data_processed = exp.data_processor(source_data=resp_data)
-            csv_generator_status, sts, msg = exp.csv_generator(
-                data=data_processed, fields=labels, filename=filename)
+            csv_generator_status, sts, file, msg = exp.csv_generator(
+                data=data_processed, fields=labels)
         else:
             sts, msg = resp_data.get("status"), resp_data.get("error")
 
@@ -93,6 +93,6 @@ async def export(
             "method": request.method,
             "request_path": request.url.path})
     if sts == "success":
-        return FileResponse(path=filename,
-                            background=BackgroundTask(exp.cleanup_files, filename))
+        return FileResponse(path=file,
+                            background=BackgroundTask(exp.cleanup_files, file))
     return {"status": sts, "query": expr, "message": msg}

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -1,5 +1,6 @@
 from jsonschema import validate, exceptions
 from src.utils.arguments import arg_parser
+from uuid import uuid4
 import requests
 import json
 import copy
@@ -102,18 +103,19 @@ def cleanup_files(file) -> tuple[True, str]:
         return True, "File has been removed successfully"
 
 
-def csv_generator(data, fields, filename) -> tuple[bool, str, str]:
+def csv_generator(data, fields) -> tuple[bool, str, str, str]:
     """
     This function generates a CSV file
     based on the provided objects.
     """
+    file_path = f"/tmp/{str(uuid4())}.csv"
     try:
-        with open(filename, 'w') as csvfile:
+        with open(file_path, 'w') as csvfile:
             writer = csv.DictWriter(
                 csvfile, fieldnames=fields, extrasaction='ignore')
             writer.writeheader()
             writer.writerows(data)
     except BaseException as e:
-        return False, "error", str(e)
+        return False, "error", "", str(e)
     else:
-        return True, "success", "CSV file has been generated successfully"
+        return True, "success", file_path, "CSV file has been generated successfully"


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- The following PR adds a fix to the functionality that generates CSV files, which will be processed by the server and sent to users. This change ensures that the files will have unique names instead of statically defined names, resolving the issue of responses getting mixed up between users.

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
