### PR TITLE
feature(api): Add support of replacing fields in /export API

### DIFF
--- a/src/api/v1/endpoints/export.py
+++ b/src/api/v1/endpoints/export.py
@@ -71,6 +71,7 @@ async def export(
     expr, start = data.get("expr"), data.get("start")
     end, step = data.get("end"), data.get("step")
     file, file_format = None, format.lower()
+    custom_fields = data.get("replace_fields")
     validation_status, response.status_code, sts, msg = exp.validate_request(
         "export.json", data)
     if validation_status:
@@ -80,7 +81,8 @@ async def export(
             query=expr, start=start,
             end=end, step=step)
         if resp_status:
-            labels, data_processed = exp.data_processor(source_data=resp_data)
+            labels, data_processed = exp.data_processor(
+                source_data=resp_data, custom_fields=custom_fields)
             file_generator_status, sts, response.status_code, file, msg = exp.file_generator(
                 file_format=file_format, data=data_processed, fields=labels)
         else:

--- a/src/models/export.py
+++ b/src/models/export.py
@@ -7,6 +7,7 @@ class ExportData(BaseModel, extra=Extra.allow):
     start: Optional[str] = None
     end: Optional[str] = None
     step: Optional[str] = None
+    replace_fields: Optional[dict] = dict()
     _request_body_examples = {
         "Count of successful logins by users per hour in a day": {
             "description": "Count of successful logins by users per hour in a day",
@@ -14,7 +15,11 @@ class ExportData(BaseModel, extra=Extra.allow):
                 "expr": "users_login_count{status='success'}",
                 "start": "2024-01-30T00:00:00Z",
                 "end": "2024-01-31T23:59:59Z",
-                "step": "1h"
+                "step": "1h",
+                "replace_fields": {
+                    "__name__": "Name",
+                    "timestamp": "Time"
+                }
             }
         }
     }

--- a/src/schemas/export.json
+++ b/src/schemas/export.json
@@ -16,6 +16,9 @@
     "step": {
       "type": ["string", "null"],
       "pattern": "^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$"
+    },
+    "replace_fields": {
+      "type": "object"
     }
   },
   "required": ["expr"],


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- This PR adds a new feature that allows replacing Prometheus labels (fields) in the final data set: CSV, JSON, etc.

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
