### PR TITLE
feature(api): Add support of converting time formats in /export API

### DIFF
--- a/src/api/v1/endpoints/export.py
+++ b/src/api/v1/endpoints/export.py
@@ -71,7 +71,8 @@ async def export(
     expr, start = data.get("expr"), data.get("start")
     end, step = data.get("end"), data.get("step")
     file, file_format = None, format.lower()
-    custom_fields = data.get("replace_fields")
+    custom_fields, timestamp_format = data.get(
+        "replace_fields"), data.get("timestamp_format")
     validation_status, response.status_code, sts, msg = exp.validate_request(
         "export.json", data)
     if validation_status:
@@ -82,7 +83,7 @@ async def export(
             end=end, step=step)
         if resp_status:
             labels, data_processed = exp.data_processor(
-                source_data=resp_data, custom_fields=custom_fields)
+                source_data=resp_data, custom_fields=custom_fields, timestamp_format=timestamp_format)
             file_generator_status, sts, response.status_code, file, msg = exp.file_generator(
                 file_format=file_format, data=data_processed, fields=labels)
         else:

--- a/src/models/export.py
+++ b/src/models/export.py
@@ -7,15 +7,37 @@ class ExportData(BaseModel, extra=Extra.allow):
     start: Optional[str] = None
     end: Optional[str] = None
     step: Optional[str] = None
+    timestamp_format: Optional[str] = "unix"
     replace_fields: Optional[dict] = dict()
     _request_body_examples = {
-        "Count of successful logins by users per hour in a day": {
+        "User logins per hour in a day": {
             "description": "Count of successful logins by users per hour in a day",
             "value": {
                 "expr": "users_login_count{status='success'}",
                 "start": "2024-01-30T00:00:00Z",
                 "end": "2024-01-31T23:59:59Z",
+                "step": "1h"
+            }
+        },
+        "User logins per hour in a day with a user-friendly time format": {
+            "description": "Count of successful user logins per hour in a day with a user-friendly time format",
+            "value": {
+                "expr": "users_login_count{status='success'}",
+                "start": "2024-01-30T00:00:00Z",
+                "end": "2024-01-31T23:59:59Z",
                 "step": "1h",
+                "timestamp_format": "friendly"
+            }
+        },
+        "User logins per hour with friendly time format and custom fields": {
+            "description": "Count of successful user logins per hour in a day "
+                           "with a user-friendly time format and custom fields",
+            "value": {
+                "expr": "users_login_count{status='success'}",
+                "start": "2024-01-30T00:00:00Z",
+                "end": "2024-01-31T23:59:59Z",
+                "step": "1h",
+                "timestamp_format": "friendly",
                 "replace_fields": {
                     "__name__": "Name",
                     "timestamp": "Time"

--- a/src/schemas/export.json
+++ b/src/schemas/export.json
@@ -17,6 +17,10 @@
       "type": ["string", "null"],
       "pattern": "^((([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?|0)$"
     },
+    "timestamp_format": {
+      "type": ["string"],
+      "pattern": "^(unix|iso8601|rfc2822|rfc3339|friendly)$"
+    },
     "replace_fields": {
       "type": "object"
     }


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- Adds functionality to change the timestamp format while exporting data via the /export API. Previously, the default value was Unix timestamp. Now, you can choose from the following options: `iso8601`, `rfc2822`, `rfc3339`, `friendly` and `unix` which is the default.
- Updated the request body example for the /export API.

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
