### PR TITLE
fix(schemas): Add new definitions in configs.json 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1 / 2024-12-07
+
+* [BUGFIX] Fixed JSON schema validations for configuration management API. #59 
+
 ## 0.5.0 / 2024-12-06
 
 * [REFACTOR] Created a `PrometheusAPIClient` class for core API functionalities such as creating/deleting rule files and updating/reloading configurations. Removed a duplicated validation function and moved it to the utils folder. Also Updated the architecture diagram. #53

--- a/docs/examples/docker/docker-compose.yml
+++ b/docs/examples/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   prometheus:
-    image: prom/prometheus:v2.44.0
+    image: prom/prometheus:v3.0.0
     container_name: prometheus
     ports:
       - "9090:9090"

--- a/src/schemas/configs.json
+++ b/src/schemas/configs.json
@@ -623,6 +623,9 @@
           "authorization": {
             "$ref": "#/definitions/authorization"
           },
+          "enable_http2": {
+            "$ref": "#/definitions/enable_http2"
+          },
           "oauth2": {
             "$ref": "#/definitions/oauth2"
           },
@@ -1009,6 +1012,9 @@
             "description": "Configure whether HTTP requests follow HTTP 3xx redirects.",
             "type": ["boolean", "null"],
             "default": true
+          },
+          "enable_http2": {
+            "$ref": "#/definitions/enable_http2"
           },
           "queue_config": {
             "description": "Configures the queue used to write to remote storage.",
@@ -1405,9 +1411,7 @@
                 "default": "10s"
               },
               "enable_http2": {
-                "description": "Whether to enable HTTP2. Default is true.",
-                "type": "boolean",
-                "default": true
+                "$ref": "#/definitions/enable_http2"
               },
               "api_version": {
                 "description": "The api version of Alertmanager.",

--- a/src/schemas/configs.json
+++ b/src/schemas/configs.json
@@ -447,6 +447,30 @@
       "type": ["string", "null"],
       "enum": ["http", "https", null]
     },
+    "enable_compression": {
+      "description": "If enable_compression is set to 'false, Prometheus will request uncompressed response from the scraped target.",
+      "type": "boolean",
+      "default": true
+    },
+    "enable_http2": {
+      "description": "Whether to enable HTTP2. Default is true.",
+      "type": "boolean",
+      "default": true
+    },
+    "track_timestamps_staleness": {
+      "description": "Controls whether Prometheus tracks staleness of the metrics that have an explicit timestamps present in scraped data. If track_timestamps_staleness is set to 'true', a staleness marker will be inserted in the TSDB when a metric is no longer present or the target is down.",
+      "type": "boolean",
+      "default": false
+    },
+    "scrape_protocols": {
+      "description": "List of the protocols to negotiate during a scrape with the client.",
+      "type": ["array", "null"],
+      "items": {
+        "type": "string",
+        "description": "The protocols to negotiate during a scrape with the client.",
+        "enum": ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+      }
+    },
     "azure_sd_configs": {
       "description": "List of Azure service discovery configurations.",
       "type": ["array", "null"],
@@ -658,6 +682,9 @@
           "authorization": {
             "$ref": "#/definitions/authorization"
           },
+          "enable_http2": {
+            "$ref": "#/definitions/enable_http2"
+          },
           "oauth2": {
             "$ref": "#/definitions/oauth2"
           },
@@ -849,13 +876,7 @@
           "default": "10s"
         },
         "scrape_protocols": {
-          "description": "List of the protocols to negotiate during a scrape with the client.",
-          "type": ["array", "null"],
-          "items": {
-            "type": "string",
-            "description": "The protocols to negotiate during a scrape with the client.",
-            "enum": ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
-          }
+          "$ref": "#/definitions/scrape_protocols"
         },
         "evaluation_interval": {
           "$ref": "#/definitions/duration",
@@ -1165,9 +1186,16 @@
             "type": "string"
           },
           "enable_http2": {
-            "description": "Whether to enable HTTP2. Default is true.",
-            "type": "boolean",
-            "default": true
+            "$ref": "#/definitions/enable_http2"
+          },
+          "enable_compression": {
+            "$ref": "#/definitions/enable_compression"
+          },
+          "track_timestamps_staleness": {
+            "$ref": "#/definitions/track_timestamps_staleness"
+          },
+          "scrape_protocols": {
+            "$ref": "#/definitions/scrape_protocols"
           },
           "scrape_interval": {
             "$ref": "#/definitions/duration",

--- a/src/schemas/configs.json
+++ b/src/schemas/configs.json
@@ -468,7 +468,7 @@
       "items": {
         "type": "string",
         "description": "The protocols to negotiate during a scrape with the client.",
-        "enum": ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+        "enum": ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4", "PrometheusText1.0.0"]
       }
     },
     "azure_sd_configs": {

--- a/src/utils/openapi.py
+++ b/src/utils/openapi.py
@@ -16,7 +16,7 @@ def openapi(app: FastAPI):
                     "providing additional features and addressing its limitations. "
                     "Running as a sidecar alongside the Prometheus server enables "
                     "users to extend the capabilities of the API.",
-        version="0.5.0",
+        version="0.5.1",
         contact={
             "name": "Hayk Davtyan",
             "url": "https://hayk96.github.io",


### PR DESCRIPTION
**1. What this PR does / why we need it:**

- Fixed JSON schema validations for configuration management API. Added missing properties such `enable_http2`, `scrape_protocols`, `track_timestamps_staleness` in the configs.json. 
- Upgrade Prometheus version to v3, in the Docker Compose file

**2. Make sure that you've checked the boxes below before you submit PR:**
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] [DCO](https://gcc.gnu.org/dco.html) signed
- [x] No conflict with the main branch.
